### PR TITLE
Only install `enum34` on py<3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-enum34==1.1.6 # backported py34 stdlib enum for py27-33
+enum34==1.1.6; python_version < '3.4'  # backported py34 stdlib enum for py27-33
 voluptuous==0.11.1


### PR DESCRIPTION
`enum34` seems to be causing some issues on newer versions of Python, example: https://github.com/iterative/dvc/issues/1995#issuecomment-491889669

Using a PEP508 environmental marker (https://www.python.org/dev/peps/pep-0508/) to only include for 3.3 or older versions of Python